### PR TITLE
Support the Java native normalizer

### DIFF
--- a/features/diacritics.feature
+++ b/features/diacritics.feature
@@ -8,7 +8,6 @@ Feature: Decode LaTeX diacritics
 
 	Scenarios: Diacritics
 		| latex   | unicode | description                                  |
-		| \\~{}   | ~       |                                              |
 		| \\\`{o} | ò       | grave accent                                 |
 		| \\\'{o} | ó       | acute accent                                 |
 		| \\^{o}  | ô       | circumflex                                   |

--- a/features/special_characters.feature
+++ b/features/special_characters.feature
@@ -15,6 +15,6 @@ Feature: Decode LaTeX special characters
     | \\{                  | {       |
     | \\}                  | }       |
     | \\_                  | _       |
-    | \\~{}                | ~       |
+    | \\textasciitilde{}   | ~       |
     | \\textbackslash{}    | \\      |
     | \\textasciicircum{}  | ^       |

--- a/lib/latex/decode.rb
+++ b/lib/latex/decode.rb
@@ -17,8 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #++
 
-require 'unicode'
-
 require 'latex/decode/version'
 require 'latex/decode/compatibility'
 require 'latex/decode/base'
@@ -45,7 +43,7 @@ module LaTeX
       
       Decode::Base.strip_braces(string)
       
-      Unicode::normalize_C(string)
+      LaTeX.normalize_C(string)
     end
   end
 end

--- a/lib/latex/decode/compatibility.rb
+++ b/lib/latex/decode/compatibility.rb
@@ -19,3 +19,23 @@ else
   def ruby_18; false; end
   def ruby_19; yield; end
 end
+
+if RUBY_PLATFORM == 'java'
+  require 'java'
+  
+  module LaTeX
+    def self.normalize_C(string)
+      java.text.Normalizer.normalize(string, java.text.Normalizer::Form::NFC).to_s
+    end
+  end
+  
+else
+  require 'unicode'
+  
+  module LaTeX
+    def self.normalize_C(string)
+      Unicode::normalize_C(string)
+    end
+  end
+  
+end

--- a/lib/latex/decode/punctuation.rb
+++ b/lib/latex/decode/punctuation.rb
@@ -29,6 +29,7 @@ module LaTeX
         rangle             ⟩
         textasciicircum    ^
         textbackslash      \\
+        textasciitilde     ~
       }].freeze
 
       @symbols = Hash[*%w[


### PR DESCRIPTION
The Unicode gem compiles on JRuby as a C extension, which is bad for performance (and won't run, for example, on Travis-CI). Detect when we're running under JRuby and switch to using Java's native Normalizer.  Also, Java's normalizer does not normalize a floating orphan diacritic tilde into a proper tilde (nor, I think, should it).  Support `\textasciitilde` instead.

Mostly, I'm interested in this because I want my app (which uses BibTeX-Ruby) to be able to do CI on Travis under JRuby.  But more broadly, supporting the native normalizer is a Good Thing.

I'm not sure what you think should be done about the `\textasciitilde` issue.  It's not surprising to me that some Unicode parsers would choke on a single combining tilde.  Does TeX correctly format `\~{}`?  If so, it's going to be hard to support generally, given the way you're handling diacritics -- maybe it should be handled somewhere other than the diacritic code?

In any event, I'd love to get this support into LaTeX-decode to get my builds back working on Travis under JRuby.  Let me know if you'd like another approach in the patch, and I'd be glad to do that instead.
