### PR TITLE
Conditional inclusion of unicode dependency

### DIFF
--- a/latex-decode.gemspec
+++ b/latex-decode.gemspec
@@ -7,13 +7,19 @@ require 'latex/decode/version'
 Gem::Specification.new do |s|
   s.name        = 'latex-decode'
   s.version     = LaTeX::Decode::VERSION.dup
-  s.platform    = Gem::Platform::RUBY
   s.authors     = ['Sylvester Keil']
   s.email       = ['http://sylvester.keil.or.at']
   s.homepage    = 'http://github.com/inukshuk/latex-decode'
   s.summary     = 'Decodes LaTeX to Unicode.'
   s.description = 'Decodes strings formatted in LaTeX to equivalent Unicode strings.'
   s.license     = 'GPL-3'
+
+  if RUBY_PLATFORM =~ /java/
+    s.platform    = 'java'
+  else
+    s.add_dependency('unicode', '~> 0.4')
+    s.platform    = 'ruby'
+  end
 
   s.add_development_dependency('rake', '~> 0.8')
   s.add_development_dependency('bundler', '~> 1.0')


### PR DESCRIPTION
Hi!

As discussed previously, you'll find here the simplest way of conditionally including the unicode dependency.

Your releasing workflow is a bit more complex now, and should look like this (as there is no Rakefile in the project, I haven't tried to make the stuff smoother)

```
rvm use 1.9.2
gem build latex-decode.gemspec   # latex-decode-0.0.x.gem
gem push latex-decode-0.0.x.gem

rvm use jruby
gem build latex-decode.gemspec   # latex-decode-0.0.x-java.gem
gem push latex-decode-0.0.x-java.gem
```

People only have to declare a 'latex-decode' dependency (in bibtex-ruby, for instance) and the gem installer (as well as bundler) will automatically find the accurate gem for their platform. 

No solution currently exists to build truly conditional gem specs, so releasing multiple times is the way to go for now. Gems such as rake-compiler (https://github.com/luislavena/rake-compiler) tackle the problem more effectively, but that solution seems overkilled here.

Tell me what you think!
