### PR TITLE
Fix warnings about space in method definitions

### DIFF
--- a/lib/latex/decode.rb
+++ b/lib/latex/decode.rb
@@ -31,7 +31,7 @@ require 'latex/decode/greek'
 module LaTeX
 
   class << self
-    def decode (string)
+    def decode(string)
       return string unless string.respond_to?(:to_s)
 
       string = string.is_a?(String) ? string.dup : string.to_s

--- a/lib/latex/decode/base.rb
+++ b/lib/latex/decode/base.rb
@@ -7,7 +7,7 @@ module LaTeX
       class << self
         attr_reader :patterns, :map
 
-        def inherited (base)
+        def inherited(base)
           subclasses << base
         end
 
@@ -15,11 +15,11 @@ module LaTeX
           @subclasses ||= []
         end
 
-        def decode (string)
+        def decode(string)
           decode!(string.dup)
         end
 
-        def decode! (string)
+        def decode!(string)
           patterns.each do |pattern|
             string.gsub!(pattern) { |m| [$2,map[$1],$3].compact.join }
           end
@@ -32,7 +32,7 @@ module LaTeX
 
       module_function
 
-      def normalize (string)
+      def normalize(string)
         string.gsub!(/\\(?:i|j)\b/) { |m| m == '\\i' ? 'ı' : 'ȷ' }
 
         # \foo\ bar -> \foo{} bar
@@ -50,7 +50,7 @@ module LaTeX
         string
       end
 
-      def strip_braces (string)
+      def strip_braces(string)
         string.gsub!(/(^|[^\\])([\{\}]+)/, '\1')
         string.gsub!(/\\(\{|\})/, '\1')
         string

--- a/lib/latex/decode/maths.rb
+++ b/lib/latex/decode/maths.rb
@@ -6,7 +6,7 @@ module LaTeX
         /\$([^\$]+)\$/
       ].freeze
 
-      def self.decode! (string)
+      def self.decode!(string)
         patterns.each do |pattern|
           string.gsub!(pattern) do
             LaTeX.to_math_ml($1)


### PR DESCRIPTION
i.e. converted "def name (args)" to "def name(args)"
to avoid repeats of:
"warning: parentheses after method name is interpreted as an argument list, not a decomposed argument"

