### PR TITLE
Fix issues with`~x` and `\,`

### DIFF
--- a/features/step_definitions/latex.rb
+++ b/features/step_definitions/latex.rb
@@ -5,3 +5,8 @@ end
 Then /^the result should be ('|")(.*)\1$/ do |quote,value|
   expect(@result).to eq(value)
 end
+
+# For whitespace or other characters that are hard to read in source code:
+Then /^I should get '([^']*)' \+ U\+(\h{4,}) \+ '([^']*)'$/ do |pre,code,post|
+  expect(@result).to eq(pre + code.hex.chr(Encoding::UTF_8) + post)
+end

--- a/features/symbols.feature
+++ b/features/symbols.feature
@@ -12,10 +12,3 @@ Feature: Decode LaTeX symbol directives
     | \\uparrow            | ↑       |
     | \\downarrow          | ↓       |
     | \\rightarrow         | →       |
-
-  Scenarios: Whitespace
-    | latex | unicode | description        |
-    | x\\,x | x x     | small space        |
-    | x~x   | x x     | non-breaking space |
-    | ~x    |  x      | non-breaking space |
-

--- a/features/whitespace.feature
+++ b/features/whitespace.feature
@@ -1,0 +1,13 @@
+Feature: Decode LaTeX whitespace directives
+  As a hacker who works with LaTeX
+  I want to be able to decode LaTeX whitespace
+
+  Scenario Outline: LaTeX to Unicode transformation
+    When I decode the string '<latex>'
+    Then I should get <pre> + U+<code> + <post>
+
+  Scenarios: Whitespace
+    | latex | pre | code | post | description                |
+    | x~x   | 'x' | 00A0 | 'x'  | non-breaking space         |
+    | ~y    | ''  | 00A0 | 'y'  | leading non-breaking space |
+    | z\\,z | 'z' | 2009 | 'z'  | small space                |

--- a/features/whitespace.feature
+++ b/features/whitespace.feature
@@ -10,4 +10,19 @@ Feature: Decode LaTeX whitespace directives
     | latex | pre | code | post | description                |
     | x~x   | 'x' | 00A0 | 'x'  | non-breaking space         |
     | ~y    | ''  | 00A0 | 'y'  | leading non-breaking space |
-    | z\\,z | 'z' | 2009 | 'z'  | small space                |
+    | z\\,z | 'z' | 202F | 'z'  | narrow no-break space      |
+
+    # In LaTeX, `\,` produces a kern that is ⅙ em wide. A kern is a
+    # non-breaking space that is not subject to compression or expansion when
+    # determining optimal line breaks. The ideal representation might be a
+    # non-breaking variant of U+2006 Six-Per-Em Space, but the best option
+    # that exists seems to be U+202F Narrow No-Break Space. While U+202F
+    # doesn't have an explicit width, Unicode Standard Annex #14, “Unicode
+    # Line Breaking Algorithm,” revision 47, says:
+    #
+    # > When expanding or compressing interword space according to common
+    # > typographical practice, only the spaces marked by U+0020 SPACE and
+    # > U+00A0 NO-BREAK SPACE are subject to compression, and only spaces
+    # > marked by U+0020 SPACE, U+00A0 NO-BREAK SPACE, and occasionally spaces
+    # > marked by U+2009 THIN SPACE are subject to expansion. All other space
+    # > characters normally have fixed width.

--- a/lib/latex/decode/symbols.rb
+++ b/lib/latex/decode/symbols.rb
@@ -211,7 +211,7 @@ module LaTeX
         tone2             ˨
         tone1             ˩
         ss                ß
-        ,                 \u2009
+        ,                 \u202F
       }.map { |s| LaTeX.to_unicode(s) }].freeze
 
 


### PR DESCRIPTION
Hi! I've made an attempt at fixing https://github.com/inukshuk/latex-decode/issues/13 along the lines you suggested. The first commit doesn't change any behavior: it just makes the tests easier to debug—and, for me, gets them passing—by no longer using the whitespace characters literally in the examples. The second commit then changes `\,` to use U+202F.